### PR TITLE
Allow previewing without token

### DIFF
--- a/eager-satismeter.js
+++ b/eager-satismeter.js
@@ -1,9 +1,5 @@
 window.EagerSatisMeter = {
   init: function(options) {
-    if (!options.token) {
-      return;
-    }
-
     window.satismeter = window.satismeter || function() {
       (window.satismeter.q = window.satismeter.q || []).push(arguments);
     };


### PR DESCRIPTION
This makes it possible for users to see survey in action even before
they sign-up for SatisMeter account.